### PR TITLE
Enable strict TypeScript checks

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- enable `strict` mode in the frontend tsconfig

## Testing
- `pnpm run check` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683a540ebfcc83329293b5bbd9aca044