### PR TITLE
Add WebSocket job status list

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,0 +1,10 @@
+import JobStatusList from '../../src/components/JobStatusList';
+
+export default function DashboardPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center space-y-4">
+      <h1 className="text-2xl font-bold">Dashboard</h1>
+      <JobStatusList userId="demo-user" />
+    </main>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,7 +1,10 @@
+import DragAndDropUpload from '../src/components/DragAndDropUpload';
+
 export default function Page() {
   return (
-    <main className="flex min-h-screen items-center justify-center">
+    <main className="flex min-h-screen flex-col items-center justify-center space-y-4">
       <h1 className="text-2xl font-bold">Hello Next.js 14!</h1>
+      <DragAndDropUpload />
     </main>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,10 @@
+import DragAndDropUpload from '../components/DragAndDropUpload';
+
 export default function Page() {
   return (
-    <main className="flex min-h-screen items-center justify-center">
+    <main className="flex min-h-screen flex-col items-center justify-center space-y-4">
       <h1 className="text-2xl font-bold">Hello Next.js 14!</h1>
+      <DragAndDropUpload />
     </main>
   );
 }

--- a/frontend/src/components/DragAndDropUpload.tsx
+++ b/frontend/src/components/DragAndDropUpload.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState, useRef, DragEvent, ChangeEvent } from 'react';
+
+export default function DragAndDropUpload() {
+  const [file, setFile] = useState<File | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleFiles = (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const f = files[0];
+    if (f.type !== 'application/pdf' && !f.name.toLowerCase().endsWith('.pdf')) {
+      return;
+    }
+    setFile(f);
+  };
+
+  const onDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragging(false);
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const onDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragging(true);
+  };
+
+  const onDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragging(false);
+  };
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    handleFiles(e.target.files);
+  };
+
+  const upload = async () => {
+    if (!file) return;
+    setLoading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const res = await fetch('/api/upload', {
+        method: 'POST',
+        body: formData,
+      });
+      if (res.ok) {
+        const data = await res.json();
+        // eslint-disable-next-line no-console
+        console.log(data.job_id);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('Upload failed');
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center">
+      <div
+        className={`flex h-40 w-80 cursor-pointer items-center justify-center rounded border-2 border-dashed ${dragging ? 'border-blue-500' : 'border-gray-300'}`}
+        onDrop={onDrop}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onClick={() => inputRef.current?.click()}
+        role="button"
+        tabIndex={0}
+      >
+        {file ? (
+          <div className="text-center">
+            <p>{file.name}</p>
+            <p className="text-sm text-gray-500">{(file.size / 1024).toFixed(2)} KB</p>
+          </div>
+        ) : (
+          <p>Drag & Drop PDF here or click to select</p>
+        )}
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".pdf"
+        onChange={onChange}
+        className="hidden"
+      />
+      {file && (
+        <button
+          type="button"
+          onClick={upload}
+          className="mt-4 rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+          disabled={loading}
+        >
+          {loading ? (
+            <svg
+              className="h-5 w-5 animate-spin text-white"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+              />
+            </svg>
+          ) : (
+            'Upload'
+          )}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/JobStatusList.tsx
+++ b/frontend/src/components/JobStatusList.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+interface Job {
+  job_id: string;
+  status: string;
+}
+
+function useWebSocket(url: string, onMessage: (data: Job) => void) {
+  useEffect(() => {
+    const socket = new WebSocket(url);
+    socket.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data) as Job;
+        onMessage(data);
+      } catch {
+        // ignore parse errors
+      }
+    };
+    return () => {
+      socket.close();
+    };
+  }, [url, onMessage]);
+}
+
+export default function JobStatusList({ userId }: { userId: string }) {
+  const [jobs, setJobs] = useState<Record<string, string>>({});
+
+  const handleMessage = useCallback((data: Job) => {
+    setJobs((prev) => ({ ...prev, [data.job_id]: data.status }));
+  }, []);
+
+  useWebSocket(
+    typeof window === 'undefined'
+      ? ''
+      : `ws://${window.location.host}/ws/jobs/${userId}`,
+    handleMessage,
+  );
+
+  const entries = Object.entries(jobs);
+
+  return (
+    <ul className="space-y-2">
+      {entries.map(([id, status]) => (
+        <li key={id} className="flex items-center space-x-2">
+          <span className="font-mono text-sm">{id}</span>
+          <span>{status}</span>
+          {status === 'extracted' && (
+            <button
+              type="button"
+              className="rounded bg-blue-500 px-2 py-1 text-white hover:bg-blue-600"
+            >
+              Download CSV
+            </button>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- add `JobStatusList` component that listens to `/ws/jobs/{user_id}`
- show job statuses with a button placeholder when jobs are extracted
- create dashboard page that uses the component

## Testing
- `pnpm run lint` *(fails: node_modules missing)*
- `pnpm run build` *(fails: next not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ab7c7fbec833289d7c084378c4ed6