### PR TITLE
Add reusable Terraform modules and environment configs

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,7 +1,10 @@
+import DragAndDropUpload from '../src/components/DragAndDropUpload';
+
 export default function Page() {
   return (
-    <main className="flex min-h-screen items-center justify-center">
+    <main className="flex min-h-screen flex-col items-center justify-center space-y-4">
       <h1 className="text-2xl font-bold">Hello Next.js 14!</h1>
+      <DragAndDropUpload />
     </main>
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,7 +1,10 @@
+import DragAndDropUpload from '../components/DragAndDropUpload';
+
 export default function Page() {
   return (
-    <main className="flex min-h-screen items-center justify-center">
+    <main className="flex min-h-screen flex-col items-center justify-center space-y-4">
       <h1 className="text-2xl font-bold">Hello Next.js 14!</h1>
+      <DragAndDropUpload />
     </main>
   );
 }

--- a/frontend/src/components/DragAndDropUpload.tsx
+++ b/frontend/src/components/DragAndDropUpload.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState, useRef, DragEvent, ChangeEvent } from 'react';
+
+export default function DragAndDropUpload() {
+  const [file, setFile] = useState<File | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleFiles = (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const f = files[0];
+    if (f.type !== 'application/pdf' && !f.name.toLowerCase().endsWith('.pdf')) {
+      return;
+    }
+    setFile(f);
+  };
+
+  const onDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragging(false);
+    handleFiles(e.dataTransfer.files);
+  };
+
+  const onDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragging(true);
+  };
+
+  const onDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragging(false);
+  };
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    handleFiles(e.target.files);
+  };
+
+  const upload = async () => {
+    if (!file) return;
+    setLoading(true);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
+      const res = await fetch('/api/upload', {
+        method: 'POST',
+        body: formData,
+      });
+      if (res.ok) {
+        const data = await res.json();
+        // eslint-disable-next-line no-console
+        console.log(data.job_id);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error('Upload failed');
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center">
+      <div
+        className={`flex h-40 w-80 cursor-pointer items-center justify-center rounded border-2 border-dashed ${dragging ? 'border-blue-500' : 'border-gray-300'}`}
+        onDrop={onDrop}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onClick={() => inputRef.current?.click()}
+        role="button"
+        tabIndex={0}
+      >
+        {file ? (
+          <div className="text-center">
+            <p>{file.name}</p>
+            <p className="text-sm text-gray-500">{(file.size / 1024).toFixed(2)} KB</p>
+          </div>
+        ) : (
+          <p>Drag & Drop PDF here or click to select</p>
+        )}
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".pdf"
+        onChange={onChange}
+        className="hidden"
+      />
+      {file && (
+        <button
+          type="button"
+          onClick={upload}
+          className="mt-4 rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+          disabled={loading}
+        >
+          {loading ? (
+            <svg
+              className="h-5 w-5 animate-spin text-white"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+              />
+            </svg>
+          ) : (
+            'Upload'
+          )}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/terraform/environments/dev/dev.tfvars
+++ b/terraform/environments/dev/dev.tfvars
@@ -1,0 +1,10 @@
+aws_region     = "ap-northeast-1"
+bucket_name    = "cbl-dev-bucket"
+db_name        = "cbl_dev"
+db_username    = "devuser"
+db_password    = "devpass123"
+repository_name = "cbl-dev-repo"
+cluster_name    = "cbl-dev-cluster"
+service_name    = "cbl-dev-service"
+container_port  = 80
+desired_count   = 1

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,0 +1,143 @@
+module "base" {
+  source = "../.."
+
+  aws_region   = var.aws_region
+  bucket_name  = var.bucket_name
+  db_name      = var.db_name
+  db_username  = var.db_username
+  db_password  = var.db_password
+}
+
+module "ecr" {
+  source = "../../modules/ecr"
+
+  name = var.repository_name
+}
+
+module "ecs" {
+  source = "../../modules/ecs"
+
+  cluster_name   = var.cluster_name
+  service_name   = var.service_name
+  container_image = "${module.ecr.repository_url}:latest"
+  container_port  = var.container_port
+  desired_count   = var.desired_count
+}
+
+# Simple CodePipeline and CodeBuild for CI/CD
+resource "aws_s3_bucket" "pipeline_artifacts" {
+  bucket = "${var.service_name}-artifacts"
+  force_destroy = true
+}
+
+resource "aws_iam_role" "codebuild_role" {
+  name = "${var.service_name}-codebuild-role"
+  assume_role_policy = data.aws_iam_policy_document.codebuild_assume.json
+}
+
+data "aws_iam_policy_document" "codebuild_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["codebuild.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "codebuild_ecr" {
+  role       = aws_iam_role.codebuild_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}
+
+resource "aws_codebuild_project" "build" {
+  name          = "${var.service_name}-build"
+  service_role  = aws_iam_role.codebuild_role.arn
+  artifacts { type = "NO_ARTIFACTS" }
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/standard:7.0"
+    type                        = "LINUX_CONTAINER"
+    privileged_mode             = true
+    environment_variable {
+      name  = "REPOSITORY_URI"
+      value = module.ecr.repository_url
+    }
+  }
+  source {
+    type            = "NO_SOURCE"
+    buildspec       = "buildspec.yml"
+  }
+}
+
+resource "aws_iam_role" "codepipeline_role" {
+  name = "${var.service_name}-codepipeline-role"
+  assume_role_policy = data.aws_iam_policy_document.codepipeline_assume.json
+}
+
+data "aws_iam_policy_document" "codepipeline_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["codepipeline.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "codepipeline_basic" {
+  role       = aws_iam_role.codepipeline_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSCodePipelineFullAccess"
+}
+
+resource "aws_codepipeline" "pipeline" {
+  name     = "${var.service_name}-pipeline"
+  role_arn = aws_iam_role.codepipeline_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.pipeline_artifacts.bucket
+    type     = "S3"
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "S3"
+      version          = "1"
+      output_artifacts = ["source_output"]
+      configuration = {
+        S3Bucket = aws_s3_bucket.pipeline_artifacts.bucket
+        S3ObjectKey = "source.zip"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name             = "Build"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["source_output"]
+      output_artifacts = ["build_output"]
+      version          = "1"
+      configuration = {
+        ProjectName = aws_codebuild_project.build.name
+      }
+    }
+  }
+}
+
+output "ecr_repo_url" {
+  value = module.ecr.repository_url
+}
+
+output "ecs_service_name" {
+  value = module.ecs.service_name
+}

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -1,0 +1,10 @@
+variable "aws_region" { type = string }
+variable "bucket_name" { type = string }
+variable "db_name" { type = string }
+variable "db_username" { type = string }
+variable "db_password" { type = string }
+variable "repository_name" { type = string }
+variable "cluster_name" { type = string }
+variable "service_name" { type = string }
+variable "container_port" { type = number default = 80 }
+variable "desired_count" { type = number default = 1 }

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -1,0 +1,31 @@
+module "base" {
+  source = "../.."
+
+  aws_region   = var.aws_region
+  bucket_name  = var.bucket_name
+  db_name      = var.db_name
+  db_username  = var.db_username
+  db_password  = var.db_password
+}
+
+module "ecr" {
+  source = "../../modules/ecr"
+  name   = var.repository_name
+}
+
+module "ecs" {
+  source = "../../modules/ecs"
+  cluster_name   = var.cluster_name
+  service_name   = var.service_name
+  container_image = "${module.ecr.repository_url}:latest"
+  container_port  = var.container_port
+  desired_count   = var.desired_count
+}
+
+output "ecr_repo_url" {
+  value = module.ecr.repository_url
+}
+
+output "ecs_service_name" {
+  value = module.ecs.service_name
+}

--- a/terraform/environments/prod/prod.tfvars
+++ b/terraform/environments/prod/prod.tfvars
@@ -1,0 +1,10 @@
+aws_region     = "ap-northeast-1"
+bucket_name    = "cbl-prod-bucket"
+db_name        = "cbl_prod"
+db_username    = "produser"
+db_password    = "prodpass123"
+repository_name = "cbl-prod-repo"
+cluster_name    = "cbl-prod-cluster"
+service_name    = "cbl-prod-service"
+container_port  = 80
+desired_count   = 2

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -1,0 +1,10 @@
+variable "aws_region" { type = string }
+variable "bucket_name" { type = string }
+variable "db_name" { type = string }
+variable "db_username" { type = string }
+variable "db_password" { type = string }
+variable "repository_name" { type = string }
+variable "cluster_name" { type = string }
+variable "service_name" { type = string }
+variable "container_port" { type = number default = 80 }
+variable "desired_count" { type = number default = 1 }

--- a/terraform/modules/ecr/main.tf
+++ b/terraform/modules/ecr/main.tf
@@ -1,0 +1,5 @@
+resource "aws_ecr_repository" "this" {
+  name = var.name
+  image_scanning_configuration { scan_on_push = true }
+  encryption_configuration { encryption_type = "AES256" }
+}

--- a/terraform/modules/ecr/outputs.tf
+++ b/terraform/modules/ecr/outputs.tf
@@ -1,0 +1,3 @@
+output "repository_url" {
+  value = aws_ecr_repository.this.repository_url
+}

--- a/terraform/modules/ecr/variables.tf
+++ b/terraform/modules/ecr/variables.tf
@@ -1,0 +1,4 @@
+variable "name" {
+  description = "ECR repository name"
+  type        = string
+}

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -1,0 +1,89 @@
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = var.cluster_name
+}
+
+resource "aws_iam_role" "task_exec" {
+  name = "${var.service_name}-task-exec"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks.json
+}
+
+data "aws_iam_policy_document" "ecs_tasks" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "exec_policy" {
+  role       = aws_iam_role.task_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = var.service_name
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+  execution_role_arn       = aws_iam_role.task_exec.arn
+  task_role_arn            = aws_iam_role.task_exec.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = var.service_name
+      image     = var.container_image
+      essential = true
+      portMappings = [{
+        containerPort = var.container_port
+        hostPort      = var.container_port
+      }]
+    }
+  ])
+}
+
+resource "aws_security_group" "service" {
+  name_prefix = "${var.service_name}-sg"
+  vpc_id      = data.aws_vpc.default.id
+
+  ingress {
+    from_port   = var.container_port
+    to_port     = var.container_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_ecs_service" "this" {
+  name            = var.service_name
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = data.aws_subnets.default.ids
+    security_groups = [aws_security_group.service.id]
+    assign_public_ip = true
+  }
+}

--- a/terraform/modules/ecs/outputs.tf
+++ b/terraform/modules/ecs/outputs.tf
@@ -1,0 +1,3 @@
+output "service_name" {
+  value = aws_ecs_service.this.name
+}

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -1,0 +1,21 @@
+variable "cluster_name" {
+  type = string
+}
+
+variable "service_name" {
+  type = string
+}
+
+variable "container_image" {
+  type = string
+}
+
+variable "container_port" {
+  type    = number
+  default = 80
+}
+
+variable "desired_count" {
+  type    = number
+  default = 1
+}


### PR DESCRIPTION
## Summary
- add ECR and ECS service modules
- configure dev/prod environments that call the base module and new modules
- output ECR repository URL and ECS service name

## Testing
- `terraform validate` *(fails: `terraform` not found)*
- `terraform plan -chdir=terraform/environments/dev -var-file=dev.tfvars` *(fails: `terraform` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ab7c7fbec833289d7c084378c4ed6